### PR TITLE
reduce dependence on envvars

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -70,7 +70,7 @@ getTmpFileName :: IO String
 getTmpFileName = do
     dir  <- getTemporaryDirectory
     name <- getEnv "USER"
-    return (dir ++ [pathSeparator] ++ "hsp_rerun_" ++ name)
+    return (dir </> "hsp_rerun_" ++ name)
 
 main :: IO ()
 main = do
@@ -78,10 +78,14 @@ main = do
     let color          = if noColor options then colorNo else colorYes
     let mcolor         = T.unpack . color
     let (cmds, second) = fromMaybe ("", []) (uncons (args options))
-    macroFile <- (++ pathSeparator : "hsp_user_macros.json")
-        <$> getEnv "HSP_MACRO_DIR"
-    macroGroupFile <- (++ pathSeparator : "hsp_group_macros.json")
-        <$> getEnv "HSP_GROUP_MACRO_DIR"
+    macroFile <- do
+      mdir <- lookupEnv "HSP_MACRO_DIR"
+      dir <- maybe (getEnv "HOME") return mdir
+      return $ dir </> "hsp_user_macros.json"
+    macroGroupFile <- do
+      mdir <- lookupEnv "HSP_GROUP_MACRO_DIR"
+      dir <- maybe (getEnv "HOME") return mdir
+      return $ dir </> "hsp_group_macros.json"
     macroMap      <- mkMacroMapFromFile macroFile
     macroGroupMap <- mkMacroMapFromFile macroGroupFile
     let macroCombinedMap = if macroGroup options

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -41,20 +41,20 @@ runCommands :: String -> PipeEnv -> Interpreter PipeEnv
 runCommands cmds pipeEnv = do
     let tokenPipe = tokenPipeline cmds (macroMap pipeEnv)
         pipeEnv'  = pipeEnv { keepHistory = any (any isHistory) tokenPipe }
-    customDirectory <- liftIO $ getEnv "HSP_CUSTOM"
-    b               <-
-        liftIO
-        $  doesPathExist
-        $  customDirectory
-        ++ [pathSeparator]
-        ++ "HspCustom.hs"
-    when
-        b
-        (do
-            set [searchPath := [customDirectory]]
-            loadModules ["HspCustom"]
-            setTopLevelModules ["HspCustom"]
-        )
+    customDirectory <- liftIO $ lookupEnv "HSP_CUSTOM"
+    case customDirectory of
+      Nothing -> return ()
+      Just dir -> do
+        b <- liftIO
+             $  doesPathExist
+             $  dir </> "HspCustom.hs"
+        when
+          b
+          (do
+              set [searchPath := [dir]]
+              loadModules ["HspCustom"]
+              setTopLevelModules ["HspCustom"]
+          )
     setImportsQ
         [ ("Prelude"    , Nothing)
         , ("Data.Text"  , Just "T")

--- a/hsphint/hsphint.cabal
+++ b/hsphint/hsphint.cabal
@@ -19,6 +19,7 @@ library
                      , aeson
                      , unordered-containers
                      , text
+                     , directory
                      , filepath
                      , filemanip
                      , process

--- a/hsphint/src/HspCommands.hs
+++ b/hsphint/src/HspCommands.hs
@@ -6,6 +6,7 @@ import           Text.Regex
 import           Data.List
 import           Data.Maybe
 import qualified Data.Text                     as T
+import           System.Directory               ( getCurrentDirectory )
 import           System.Environment             ( getEnv )
 import           System.FilePath                ( pathSeparator
                                                 , splitFileName
@@ -234,7 +235,7 @@ quote = "\""
 
 globFunc :: String -> IO [Text]
 globFunc s = do
-  pwd <- getEnv "HSP_PWD"
+  pwd <- getCurrentDirectory
   let prefix  = pwd ++ [pathSeparator]
       -- if glob pattern relative, need to prefix it with correct directory
       globStr = if head s == pathSeparator then s else prefix ++ s
@@ -248,9 +249,9 @@ envFunc :: String -> IO Text
 envFunc s = pack <$> getEnv (drop 3 s)
 
 pwdFunc :: IO Text
-pwdFunc = pack <$> getEnv "HSP_PWD"
+pwdFunc = pack <$> getCurrentDirectory
 
 shellFunc :: String -> IO [Text]
 shellFunc s = do
-  pwd <- getEnv "HSP_PWD"
+  pwd <- getCurrentDirectory
   T.lines . pack <$> readCreateProcess ((shell s) { cwd = Just pwd }) ""

--- a/src/Process.hs
+++ b/src/Process.hs
@@ -13,7 +13,6 @@ import qualified Data.HashMap.Strict           as H
 import           Data.List
 import qualified Data.Text                     as T
 import           Data.Text                      ( Text )
-import           System.FilePath                ( pathSeparator )
 
 import           Functions
 import           Parser


### PR DESCRIPTION
With these changes, I can `cabal install` and run examples without needing to set to any envvars.